### PR TITLE
Set FD_CLOEXEC for ipmi driver device file.

### DIFF
--- a/libfreeipmi/driver/ipmi-inteldcmi-driver.c
+++ b/libfreeipmi/driver/ipmi-inteldcmi-driver.c
@@ -423,6 +423,7 @@ int
 ipmi_inteldcmi_ctx_io_init (ipmi_inteldcmi_ctx_t ctx)
 {
   char *driver_device;
+  int flags;
 
   if (!ctx || ctx->magic != IPMI_INTELDCMI_CTX_MAGIC)
     {
@@ -441,6 +442,19 @@ ipmi_inteldcmi_ctx_io_init (ipmi_inteldcmi_ctx_t ctx)
   if ((ctx->device_fd = open (driver_device, O_RDWR)) < 0)
     {
       INTELDCMI_ERRNO_TO_INTELDCMI_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+
+  flags = fcntl(ctx->device_fd, F_GETFD);
+  if (flags == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+  flags |= FD_CLOEXEC;
+  if (fcntl(ctx->device_fd, F_SETFD, flags) == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
       goto cleanup;
     }
 

--- a/libfreeipmi/driver/ipmi-openipmi-driver.c
+++ b/libfreeipmi/driver/ipmi-openipmi-driver.c
@@ -352,6 +352,7 @@ ipmi_openipmi_ctx_io_init (ipmi_openipmi_ctx_t ctx)
 {
   unsigned int addr = IPMI_SLAVE_ADDRESS_BMC;
   char *driver_device;
+  int flags;
 
   if (!ctx || ctx->magic != IPMI_OPENIPMI_CTX_MAGIC)
     {
@@ -369,6 +370,19 @@ ipmi_openipmi_ctx_io_init (ipmi_openipmi_ctx_t ctx)
 
   if ((ctx->device_fd = open (driver_device,
                               O_RDWR)) < 0)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+
+  flags = fcntl(ctx->device_fd, F_GETFD);
+  if (flags == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+  flags |= FD_CLOEXEC;
+  if (fcntl(ctx->device_fd, F_SETFD, flags) == -1)
     {
       OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
       goto cleanup;

--- a/libfreeipmi/driver/ipmi-ssif-driver.c
+++ b/libfreeipmi/driver/ipmi-ssif-driver.c
@@ -679,6 +679,8 @@ ipmi_ssif_ctx_set_flags (ipmi_ssif_ctx_t ctx, unsigned int flags)
 int
 ipmi_ssif_ctx_io_init (ipmi_ssif_ctx_t ctx)
 {
+  int flags;
+
   if (!ctx || ctx->magic != IPMI_SSIF_CTX_MAGIC)
     {
       ERR_TRACE (ipmi_ssif_ctx_errormsg (ctx), ipmi_ssif_ctx_errnum (ctx));
@@ -698,6 +700,19 @@ ipmi_ssif_ctx_io_init (ipmi_ssif_ctx_t ctx)
                               O_RDWR)) < 0)
     {
       SSIF_ERRNO_TO_SSIF_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+
+  flags = fcntl(ctx->device_fd, F_GETFD);
+  if (flags == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+  flags |= FD_CLOEXEC;
+  if (fcntl(ctx->device_fd, F_SETFD, flags) == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
       goto cleanup;
     }
 

--- a/libfreeipmi/driver/ipmi-sunbmc-driver.c
+++ b/libfreeipmi/driver/ipmi-sunbmc-driver.c
@@ -303,6 +303,7 @@ ipmi_sunbmc_ctx_io_init (ipmi_sunbmc_ctx_t ctx)
   uint8_t method;
 #endif /* !(defined(HAVE_SYS_STROPTS_H) && defined(IOCTL_IPMI_INTERFACE_METHOD)) */
   char *driver_device;
+  int flags;
 
   if (!ctx || ctx->magic != IPMI_SUNBMC_CTX_MAGIC)
     {
@@ -322,6 +323,19 @@ ipmi_sunbmc_ctx_io_init (ipmi_sunbmc_ctx_t ctx)
                               O_RDWR)) < 0)
     {
       SUNBMC_ERRNO_TO_SUNBMC_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+
+  flags = fcntl(ctx->device_fd, F_GETFD);
+  if (flags == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
+      goto cleanup;
+    }
+  flags |= FD_CLOEXEC;
+  if (fcntl(ctx->device_fd, F_SETFD, flags) == -1)
+    {
+      OPENIPMI_ERRNO_TO_OPENIPMI_ERRNUM (ctx, errno);
       goto cleanup;
     }
 


### PR DESCRIPTION
If a privileged process, which uses this library, spawns a
non-privileged child, the child can inherit open file descriptor to ipmi
driver. This may become a significant both safety and security
vulnerability, if access to ipmi device file is not intended (For
details see [1]).

Another possibility for Linux is to use O_CLOEXEC flag, which is
considered to be thread safe. But F_CLOEXEC is more portable.

1. https://cwe.mitre.org/data/definitions/403.html